### PR TITLE
feat: improved color settings page

### DIFF
--- a/src/main/java/org/intellij/sdk/language/SQLTestColorSettingsPage.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestColorSettingsPage.java
@@ -12,10 +12,13 @@ import java.util.Map;
 public class SQLTestColorSettingsPage implements ColorSettingsPage {
 
     private static final AttributesDescriptor[] DESCRIPTORS = new AttributesDescriptor[]{
-            new AttributesDescriptor("Key", SQLTestSyntaxHighlighter.KEY),
-            new AttributesDescriptor("Separator", SQLTestSyntaxHighlighter.RESERVED),
-            new AttributesDescriptor("Value", SQLTestSyntaxHighlighter.VALUE),
-            new AttributesDescriptor("Bad Value", SQLTestSyntaxHighlighter.BAD_CHARACTER)
+            new AttributesDescriptor("Directive", SQLTestSyntaxHighlighter.RESERVED),
+            new AttributesDescriptor("Identifier", SQLTestSyntaxHighlighter.KEY),
+            new AttributesDescriptor("Value/Number", SQLTestSyntaxHighlighter.VALUE),
+            new AttributesDescriptor("Comment", SQLTestSyntaxHighlighter.COMMENT),
+            new AttributesDescriptor("SQL Keyword", SQLTestSyntaxHighlighter.SQL),
+            new AttributesDescriptor("Result Output", SQLTestSyntaxHighlighter.RESULT),
+            new AttributesDescriptor("Bad Character", SQLTestSyntaxHighlighter.BAD_CHARACTER)
     };
 
     @Nullable
@@ -33,7 +36,19 @@ public class SQLTestColorSettingsPage implements ColorSettingsPage {
     @NotNull
     @Override
     public String getDemoText() {
-        return " ";
+        return "# Test file example\n" +
+                "require tpch\n\n" +
+                "statement ok\n" +
+                "CREATE TABLE test (id INTEGER, name VARCHAR);\n\n" +
+                "query II\n" +
+                "SELECT id, name FROM test ORDER BY id;\n" +
+                "----\n" +
+                "1\tAlice\n" +
+                "2\tBob\n\n" +
+                "loop i 0 10\n" +
+                "statement ok\n" +
+                "INSERT INTO test VALUES (${i}, 'user');\n" +
+                "endloop\n";
     }
 
     @Nullable
@@ -57,7 +72,6 @@ public class SQLTestColorSettingsPage implements ColorSettingsPage {
     @NotNull
     @Override
     public String getDisplayName() {
-        return "Simple";
+        return "SQLTest";
     }
-
 }


### PR DESCRIPTION
Updates the Color Settings Page with:
- All 7 token categories properly labeled (Directive, Identifier, Value/Number, Comment, SQL Keyword, Result Output, Bad Character)  
- Real `.test` file demo text showing directives, SQL, results, and loops
- Display name changed from 'Simple' to 'SQLTest'

Part of #13 (Phase 3 polish)