### PR TITLE
feat: structure view for navigating .test file directives

### DIFF
--- a/src/main/java/org/intellij/sdk/language/SQLTestStructureViewElement.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestStructureViewElement.java
@@ -1,0 +1,216 @@
+package org.intellij.sdk.language;
+
+import com.intellij.ide.projectView.PresentationData;
+import com.intellij.ide.structureView.StructureViewTreeElement;
+import com.intellij.ide.util.treeView.smartTree.SortableTreeElement;
+import com.intellij.ide.util.treeView.smartTree.TreeElement;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.editor.Document;
+import com.intellij.icons.AllIcons;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Root structure element for .test files.
+ * Parses the document text to find directives and builds a tree.
+ */
+public class SQLTestStructureViewElement implements StructureViewTreeElement, SortableTreeElement {
+
+    private final PsiFile myFile;
+
+    public SQLTestStructureViewElement(@NotNull PsiFile file) {
+        this.myFile = file;
+    }
+
+    @Override
+    public Object getValue() {
+        return myFile;
+    }
+
+    @NotNull
+    @Override
+    public String getAlphaSortKey() {
+        return myFile.getName();
+    }
+
+    @NotNull
+    @Override
+    public ItemPresentation getPresentation() {
+        return new PresentationData(myFile.getName(), null, SQLTestIcons.FILE, null);
+    }
+
+    @NotNull
+    @Override
+    public TreeElement @NotNull [] getChildren() {
+        Document doc = PsiDocumentManager.getInstance(myFile.getProject()).getDocument(myFile);
+        if (doc == null) return TreeElement.EMPTY_ARRAY;
+
+        String text = doc.getText();
+        String[] lines = text.split("\n", -1);
+        List<TreeElement> elements = new ArrayList<>();
+
+        for (int i = 0; i < lines.length; i++) {
+            String trimmed = lines[i].trim();
+            String label = null;
+            String iconType = null;
+
+            if (trimmed.startsWith("statement ")) {
+                String sql = (i + 1 < lines.length) ? lines[i + 1].trim() : "";
+                if (sql.length() > 60) sql = sql.substring(0, 57) + "...";
+                label = trimmed + (sql.isEmpty() ? "" : "  \u2192  " + sql);
+                iconType = "statement";
+            } else if (trimmed.startsWith("query ")) {
+                String sql = (i + 1 < lines.length) ? lines[i + 1].trim() : "";
+                if (sql.length() > 60) sql = sql.substring(0, 57) + "...";
+                label = trimmed + (sql.isEmpty() ? "" : "  \u2192  " + sql);
+                iconType = "query";
+            } else if (trimmed.startsWith("loop ") || trimmed.startsWith("foreach ") ||
+                       trimmed.startsWith("concurrentloop ") || trimmed.startsWith("concurrentforeach ")) {
+                label = trimmed;
+                iconType = "loop";
+            } else if (trimmed.startsWith("require ") || trimmed.startsWith("require-env ")) {
+                label = trimmed;
+                iconType = "require";
+            } else if (trimmed.startsWith("load ")) {
+                label = trimmed;
+                iconType = "load";
+            } else if (trimmed.startsWith("skipif ") || trimmed.startsWith("onlyif ")) {
+                label = trimmed;
+                iconType = "condition";
+            } else if (trimmed.startsWith("mode ")) {
+                label = trimmed;
+                iconType = "mode";
+            } else if (trimmed.equals("halt")) {
+                label = "halt";
+                iconType = "halt";
+            } else if (trimmed.equals("restart")) {
+                label = "restart";
+                iconType = "restart";
+            }
+
+            if (label != null) {
+                int offset = getLineOffset(lines, i);
+                elements.add(new DirectiveElement(myFile, label, offset, iconType));
+            }
+        }
+
+        return elements.toArray(TreeElement.EMPTY_ARRAY);
+    }
+
+    private int getLineOffset(String[] lines, int lineIndex) {
+        int offset = 0;
+        for (int j = 0; j < lineIndex; j++) {
+            offset += lines[j].length() + 1;
+        }
+        return offset;
+    }
+
+    @Override
+    public void navigate(boolean requestFocus) {
+        myFile.navigate(requestFocus);
+    }
+
+    @Override
+    public boolean canNavigate() {
+        return myFile.canNavigate();
+    }
+
+    @Override
+    public boolean canNavigateToSource() {
+        return myFile.canNavigateToSource();
+    }
+
+    /**
+     * Leaf element representing a single directive in the structure view.
+     */
+    static class DirectiveElement implements StructureViewTreeElement, SortableTreeElement {
+        private final PsiFile myFile;
+        private final String myLabel;
+        private final int myOffset;
+        private final String myIconType;
+
+        DirectiveElement(@NotNull PsiFile file, @NotNull String label, int offset, String iconType) {
+            this.myFile = file;
+            this.myLabel = label;
+            this.myOffset = offset;
+            this.myIconType = iconType;
+        }
+
+        @Override
+        public Object getValue() {
+            return myLabel;
+        }
+
+        @NotNull
+        @Override
+        public String getAlphaSortKey() {
+            return myLabel;
+        }
+
+        @NotNull
+        @Override
+        public ItemPresentation getPresentation() {
+            Icon icon;
+            switch (myIconType) {
+                case "query":
+                    icon = AllIcons.Nodes.Method;
+                    break;
+                case "statement":
+                    icon = AllIcons.Nodes.Function;
+                    break;
+                case "loop":
+                    icon = AllIcons.Actions.Refresh;
+                    break;
+                case "require":
+                    icon = AllIcons.Nodes.Plugin;
+                    break;
+                case "load":
+                    icon = AllIcons.Actions.Upload;
+                    break;
+                case "condition":
+                    icon = AllIcons.Debugger.Db_set_breakpoint;
+                    break;
+                case "halt":
+                    icon = AllIcons.Actions.Suspend;
+                    break;
+                case "restart":
+                    icon = AllIcons.Actions.Restart;
+                    break;
+                default:
+                    icon = AllIcons.Nodes.Tag;
+                    break;
+            }
+            return new PresentationData(myLabel, null, icon, null);
+        }
+
+        @NotNull
+        @Override
+        public TreeElement @NotNull [] getChildren() {
+            return TreeElement.EMPTY_ARRAY;
+        }
+
+        @Override
+        public void navigate(boolean requestFocus) {
+            PsiElement elementAt = myFile.findElementAt(myOffset);
+            if (elementAt instanceof com.intellij.pom.Navigatable) {
+                ((com.intellij.pom.Navigatable) elementAt).navigate(requestFocus);
+            }
+        }
+
+        @Override
+        public boolean canNavigate() {
+            return true;
+        }
+
+        @Override
+        public boolean canNavigateToSource() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/intellij/sdk/language/SQLTestStructureViewFactory.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestStructureViewFactory.java
@@ -1,0 +1,25 @@
+package org.intellij.sdk.language;
+
+import com.intellij.ide.structureView.StructureViewBuilder;
+import com.intellij.ide.structureView.StructureViewModel;
+import com.intellij.ide.structureView.TreeBasedStructureViewBuilder;
+import com.intellij.lang.PsiStructureViewFactory;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SQLTestStructureViewFactory implements PsiStructureViewFactory {
+
+    @Nullable
+    @Override
+    public StructureViewBuilder getStructureViewBuilder(@NotNull PsiFile psiFile) {
+        return new TreeBasedStructureViewBuilder() {
+            @NotNull
+            @Override
+            public StructureViewModel createStructureViewModel(@Nullable Editor editor) {
+                return new SQLTestStructureViewModel(psiFile, editor);
+            }
+        };
+    }
+}

--- a/src/main/java/org/intellij/sdk/language/SQLTestStructureViewModel.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestStructureViewModel.java
@@ -1,0 +1,27 @@
+package org.intellij.sdk.language;
+
+import com.intellij.ide.structureView.StructureViewModel;
+import com.intellij.ide.structureView.StructureViewModelBase;
+import com.intellij.ide.structureView.StructureViewTreeElement;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SQLTestStructureViewModel extends StructureViewModelBase
+        implements StructureViewModel.ElementInfoProvider {
+
+    public SQLTestStructureViewModel(@NotNull PsiFile psiFile, @Nullable Editor editor) {
+        super(psiFile, editor, new SQLTestStructureViewElement(psiFile));
+    }
+
+    @Override
+    public boolean isAlwaysShowsPlus(StructureViewTreeElement element) {
+        return false;
+    }
+
+    @Override
+    public boolean isAlwaysLeaf(StructureViewTreeElement element) {
+        return element instanceof SQLTestStructureViewElement.DirectiveElement;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>pholanda.github.io</id>
     <name>SQLTest</name>
-    <version>1.1.2</version>
+    <version>1.2.0</version>
     <vendor email="holanda@cwi.nl" url="https://pdet.github.io">Pedro Holanda</vendor>
 
     <description><![CDATA[
@@ -12,18 +12,26 @@
             <li>Syntax highlighting for SQL keywords, directives, comments, strings, and numbers</li>
             <li>Proper result section handling (no highlighting bleed from query results)</li>
             <li>Code folding for statement/query blocks, loops, and result sections</li>
+            <li>Structure view — navigate between tests, loops, requires in the sidebar</li>
             <li>Supports .test, .test_slow, .testslow, .benchmark, and .slt files</li>
         </ul>
     ]]></description>
 
     <change-notes><![CDATA[
+        <b>1.2.0</b>
+        <ul>
+            <li>Structure view: navigate statements, queries, loops, requires from sidebar</li>
+            <li>Query/statement entries show SQL preview (first line of SQL)</li>
+            <li>Code folding for statement/query blocks, loops, and foreach blocks</li>
+            <li>Context-aware highlighting: directives, SQL keywords, dimmed result output</li>
+            <li>New directives: require, require-env, mode, halt, skipif, onlyif, foreach, etc.</li>
+        </ul>
         <b>1.1.2</b>
         <ul>
             <li>Fix: apostrophe in query results no longer breaks syntax highlighting (#10)</li>
             <li>Added RESULT_SECTION lexer state for proper result section handling</li>
             <li>Expanded SQL keyword list with modern DuckDB keywords</li>
-            <li>Code folding for statement/query blocks, loops, and foreach blocks</li>
-            <li>New directive keywords: require, mode, halt, skipif, onlyif, foreach, etc.</li>
+            <li>GitHub Actions CI</li>
         </ul>
     ]]></change-notes>
 
@@ -47,5 +55,8 @@
 
         <lang.foldingBuilder language="Test"
                              implementationClass="org.intellij.sdk.language.SQLTestFoldingBuilder"/>
+
+        <lang.psiStructureViewFactory language="Test"
+                                      implementationClass="org.intellij.sdk.language.SQLTestStructureViewFactory"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
### Structure View

Open any `.test` file and use **View → Tool Windows → Structure** (or Alt+7) to see all directives at a glance:

- **Statements** (⨍ icon) — `statement ok/error` with SQL preview
- **Queries** (ℳ icon) — `query II` with SQL preview  
- **Loops** (↻ icon) — `loop`, `foreach`, `concurrentloop`
- **Requirements** (🔌 icon) — `require`, `require-env`
- **Loads** (📁 icon) — `load` directives
- **Conditions** (● icon) — `skipif`, `onlyif`
- **Control** — `halt`, `restart`, `mode`

Click any entry to jump to that line in the editor.

Also bumps version to **1.2.0**.

Part of #13 (Phase 4: Navigation & usability)