### PR TITLE
feat: brace matching for loop/endloop and foreach/endforeach

### DIFF
--- a/src/main/java/org/intellij/sdk/language/SQLTestBraceMatcher.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestBraceMatcher.java
@@ -1,0 +1,38 @@
+package org.intellij.sdk.language;
+
+import com.intellij.lang.BracePair;
+import com.intellij.lang.PairedBraceMatcher;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
+import org.intellij.sdk.language.psi.TestTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Matches loop/endloop and foreach/endforeach pairs.
+ * Highlights the matching keyword when the cursor is on one.
+ */
+public class SQLTestBraceMatcher implements PairedBraceMatcher {
+
+    private static final BracePair[] PAIRS = new BracePair[]{
+            new BracePair(TestTypes.LOOP, TestTypes.ENDLOOP, true),
+            new BracePair(TestTypes.FOREACH, TestTypes.ENDFOREACH, true),
+            new BracePair(TestTypes.LP, TestTypes.RP, false),
+    };
+
+    @Override
+    public BracePair @NotNull [] getPairs() {
+        return PAIRS;
+    }
+
+    @Override
+    public boolean isPairedBracesAllowedBeforeType(@NotNull IElementType lbraceType,
+                                                    @Nullable IElementType contextType) {
+        return true;
+    }
+
+    @Override
+    public int getCodeConstructStart(PsiFile file, int openingBraceOffset) {
+        return openingBraceOffset;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
             <li>Code folding for statement/query blocks, loops, and result sections</li>
             <li>Structure view — navigate between tests, loops, requires in the sidebar</li>
             <li>Gutter icons — green check (statement ok), red X (statement error), play (query)</li>
+            <li>Brace matching for loop/endloop and foreach/endforeach</li>
             <li>Supports .test, .test_slow, .testslow, .benchmark, and .slt files</li>
         </ul>
     ]]></description>
@@ -22,9 +23,9 @@
         <b>1.2.0</b>
         <ul>
             <li>Structure view: navigate statements, queries, loops, requires from sidebar</li>
-            <li>Query/statement entries show SQL preview (first line of SQL)</li>
             <li>Code folding for statement/query blocks, loops, and foreach blocks</li>
             <li>Gutter icons: green check (ok), red X (error), play button (query)</li>
+            <li>Brace matching for loop/endloop and foreach/endforeach pairs</li>
             <li>Context-aware highlighting: directives, SQL keywords, dimmed result output</li>
             <li>New directives: require, require-env, mode, halt, skipif, onlyif, foreach, etc.</li>
         </ul>
@@ -63,5 +64,8 @@
 
         <codeInsight.lineMarkerProvider language="Test"
                                         implementationClass="org.intellij.sdk.language.SQLTestLineMarkerProvider"/>
+
+        <lang.braceMatcher language="Test"
+                           implementationClass="org.intellij.sdk.language.SQLTestBraceMatcher"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
### Brace Matching

Place your cursor on `loop` and the matching `endloop` lights up (and vice versa). Same for `foreach`/`endforeach`.

Also matches parentheses `()` within SQL.

Part of #13 (Phase 4: Navigation & usability)