### PR TITLE
feat: status bar widget showing test count

### DIFF
--- a/src/main/java/org/intellij/sdk/language/SQLTestStatusBarWidget.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestStatusBarWidget.java
@@ -1,0 +1,126 @@
+package org.intellij.sdk.language;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.util.Consumer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.event.MouseEvent;
+
+/**
+ * Status bar widget that shows the count of statements and queries
+ * in the currently open .test file.
+ */
+public class SQLTestStatusBarWidget implements StatusBarWidget, StatusBarWidget.TextPresentation {
+
+    private final Project myProject;
+    private StatusBar myStatusBar;
+    private String myText = "";
+
+    private static final java.util.Set<String> TEST_EXTENSIONS = java.util.Set.of(
+            "test", "test_slow", "testslow", "benchmark", "slt"
+    );
+
+    public SQLTestStatusBarWidget(@NotNull Project project) {
+        myProject = project;
+        project.getMessageBus().connect().subscribe(
+                FileEditorManagerListener.FILE_EDITOR_MANAGER,
+                new FileEditorManagerListener() {
+                    @Override
+                    public void selectionChanged(@NotNull FileEditorManagerEvent event) {
+                        updateWidget();
+                    }
+                }
+        );
+    }
+
+    @NotNull
+    @Override
+    public String ID() {
+        return "SQLTestCounter";
+    }
+
+    @Override
+    public void install(@NotNull StatusBar statusBar) {
+        myStatusBar = statusBar;
+        updateWidget();
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+    @NotNull
+    @Override
+    public String getText() {
+        return myText;
+    }
+
+    @NotNull
+    @Override
+    public String getTooltipText() {
+        return "Number of statement and query blocks in this .test file";
+    }
+
+    @Nullable
+    @Override
+    public Consumer<MouseEvent> getClickConsumer() {
+        return null;
+    }
+
+    @Override
+    public float getAlignment() {
+        return 0.5f;
+    }
+
+    @NotNull
+    @Override
+    public WidgetPresentation getPresentation() {
+        return this;
+    }
+
+    private void updateWidget() {
+        Editor editor = FileEditorManager.getInstance(myProject).getSelectedTextEditor();
+        if (editor == null) {
+            myText = "";
+            if (myStatusBar != null) myStatusBar.updateWidget(ID());
+            return;
+        }
+
+        VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+        if (file == null || !isTestFile(file)) {
+            myText = "";
+            if (myStatusBar != null) myStatusBar.updateWidget(ID());
+            return;
+        }
+
+        Document doc = editor.getDocument();
+        String text = doc.getText();
+        String[] lines = text.split("\n", -1);
+
+        int statements = 0;
+        int queries = 0;
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("statement ")) statements++;
+            else if (trimmed.startsWith("query ")) queries++;
+        }
+
+        myText = "\uD83E\uDD86 " + statements + " stmt, " + queries + " query";
+        if (myStatusBar != null) myStatusBar.updateWidget(ID());
+    }
+
+    private boolean isTestFile(@NotNull VirtualFile file) {
+        String ext = file.getExtension();
+        return ext != null && TEST_EXTENSIONS.contains(ext);
+    }
+}

--- a/src/main/java/org/intellij/sdk/language/SQLTestStatusBarWidgetFactory.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestStatusBarWidgetFactory.java
@@ -1,0 +1,40 @@
+package org.intellij.sdk.language;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+public class SQLTestStatusBarWidgetFactory implements StatusBarWidgetFactory {
+
+    @NotNull
+    @Override
+    public String getId() {
+        return "SQLTestCounter";
+    }
+
+    @Nls
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "SQLTest Counter";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project) {
+        return true;
+    }
+
+    @NotNull
+    @Override
+    public StatusBarWidget createWidget(@NotNull Project project) {
+        return new SQLTestStatusBarWidget(project);
+    }
+
+    @Override
+    public void disposeWidget(@NotNull StatusBarWidget widget) {
+        widget.dispose();
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@
             <li>Structure view — navigate between tests, loops, requires in the sidebar</li>
             <li>Gutter icons — green check (statement ok), red X (statement error), play (query)</li>
             <li>Brace matching for loop/endloop and foreach/endforeach</li>
+            <li>Test counter in status bar (🦆 X stmt, Y query)</li>
             <li>Supports .test, .test_slow, .testslow, .benchmark, and .slt files</li>
         </ul>
     ]]></description>
@@ -26,6 +27,7 @@
             <li>Code folding for statement/query blocks, loops, and foreach blocks</li>
             <li>Gutter icons: green check (ok), red X (error), play button (query)</li>
             <li>Brace matching for loop/endloop and foreach/endforeach pairs</li>
+            <li>Status bar widget: shows test count for open file</li>
             <li>Context-aware highlighting: directives, SQL keywords, dimmed result output</li>
             <li>New directives: require, require-env, mode, halt, skipif, onlyif, foreach, etc.</li>
         </ul>
@@ -67,5 +69,8 @@
 
         <lang.braceMatcher language="Test"
                            implementationClass="org.intellij.sdk.language.SQLTestBraceMatcher"/>
+
+        <statusBarWidgetFactory implementation="org.intellij.sdk.language.SQLTestStatusBarWidgetFactory"
+                                id="SQLTestCounter"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
### Status Bar Widget

Shows **🦆 X stmt, Y query** in the IntelliJ status bar when editing a `.test` file.

- Counts `statement` and `query` directives in the current file
- Updates automatically when switching between files
- Only visible for test file extensions (.test, .test_slow, .testslow, .benchmark, .slt)

Part of #13 (Phase 4: Navigation & usability)