### PR TITLE
feat: Go to Next/Previous Test actions

### DIFF
--- a/src/main/java/org/intellij/sdk/language/SQLTestGoToNextAction.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestGoToNextAction.java
@@ -1,0 +1,71 @@
+package org.intellij.sdk.language;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ScrollType;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+/**
+ * Navigate to the next test directive (statement/query) in the file.
+ * Bound to Ctrl+Shift+Down (or via menu).
+ */
+public class SQLTestGoToNextAction extends AnAction {
+
+    private static final Set<String> TEST_EXTENSIONS = Set.of(
+            "test", "test_slow", "testslow", "benchmark", "slt"
+    );
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        if (editor == null) return;
+
+        Document doc = editor.getDocument();
+        int currentLine = doc.getLineNumber(editor.getCaretModel().getOffset());
+        String text = doc.getText();
+        String[] lines = text.split("\n", -1);
+
+        for (int i = currentLine + 1; i < lines.length; i++) {
+            String trimmed = lines[i].trim();
+            if (isTestDirective(trimmed)) {
+                int offset = getLineStartOffset(lines, i);
+                editor.getCaretModel().moveToOffset(offset);
+                editor.getScrollingModel().scrollToCaret(ScrollType.CENTER);
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        boolean enabled = false;
+        if (editor != null) {
+            VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+            if (file != null) {
+                String ext = file.getExtension();
+                enabled = ext != null && TEST_EXTENSIONS.contains(ext);
+            }
+        }
+        e.getPresentation().setEnabledAndVisible(enabled);
+    }
+
+    private boolean isTestDirective(String trimmed) {
+        return trimmed.startsWith("statement ") || trimmed.startsWith("query ");
+    }
+
+    private int getLineStartOffset(String[] lines, int lineIndex) {
+        int offset = 0;
+        for (int j = 0; j < lineIndex; j++) {
+            offset += lines[j].length() + 1;
+        }
+        return offset;
+    }
+}

--- a/src/main/java/org/intellij/sdk/language/SQLTestGoToPreviousAction.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestGoToPreviousAction.java
@@ -1,0 +1,71 @@
+package org.intellij.sdk.language;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ScrollType;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+/**
+ * Navigate to the previous test directive (statement/query) in the file.
+ * Bound to Ctrl+Shift+Up (or via menu).
+ */
+public class SQLTestGoToPreviousAction extends AnAction {
+
+    private static final Set<String> TEST_EXTENSIONS = Set.of(
+            "test", "test_slow", "testslow", "benchmark", "slt"
+    );
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        if (editor == null) return;
+
+        Document doc = editor.getDocument();
+        int currentLine = doc.getLineNumber(editor.getCaretModel().getOffset());
+        String text = doc.getText();
+        String[] lines = text.split("\n", -1);
+
+        for (int i = currentLine - 1; i >= 0; i--) {
+            String trimmed = lines[i].trim();
+            if (isTestDirective(trimmed)) {
+                int offset = getLineStartOffset(lines, i);
+                editor.getCaretModel().moveToOffset(offset);
+                editor.getScrollingModel().scrollToCaret(ScrollType.CENTER);
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        boolean enabled = false;
+        if (editor != null) {
+            VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+            if (file != null) {
+                String ext = file.getExtension();
+                enabled = ext != null && TEST_EXTENSIONS.contains(ext);
+            }
+        }
+        e.getPresentation().setEnabledAndVisible(enabled);
+    }
+
+    private boolean isTestDirective(String trimmed) {
+        return trimmed.startsWith("statement ") || trimmed.startsWith("query ");
+    }
+
+    private int getLineStartOffset(String[] lines, int lineIndex) {
+        int offset = 0;
+        for (int j = 0; j < lineIndex; j++) {
+            offset += lines[j].length() + 1;
+        }
+        return offset;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,7 @@
             <li>Gutter icons — green check (statement ok), red X (statement error), play (query)</li>
             <li>Brace matching for loop/endloop and foreach/endforeach</li>
             <li>Error annotations — mismatched loops, missing results, bad qualifiers</li>
+            <li>Go to Next/Previous Test (Ctrl+Shift+Down/Up)</li>
             <li>Test counter in status bar (🦆 X stmt, Y query)</li>
             <li>Supports .test, .test_slow, .testslow, .benchmark, and .slt files</li>
         </ul>
@@ -29,8 +30,10 @@
             <li>Gutter icons: green check (ok), red X (error), play button (query)</li>
             <li>Brace matching for loop/endloop and foreach/endforeach pairs</li>
             <li>Error annotations: mismatched loop/endloop, missing ----, bad statement qualifiers</li>
+            <li>Go to Next/Previous Test actions (Ctrl+Shift+Down/Up)</li>
             <li>Status bar widget: shows test count for open file</li>
             <li>Context-aware highlighting: directives, SQL keywords, dimmed result output</li>
+            <li>25 unit tests for lexer token streams</li>
             <li>New directives: require, require-env, mode, halt, skipif, onlyif, foreach, etc.</li>
         </ul>
         <b>1.1.2</b>
@@ -78,4 +81,26 @@
         <annotator language="Test"
                    implementationClass="org.intellij.sdk.language.SQLTestAnnotator"/>
     </extensions>
+
+    <actions>
+        <group id="SQLTest.NavigationGroup" text="SQLTest" popup="true">
+            <add-to-group group-id="GoToMenu" anchor="last"/>
+        </group>
+
+        <action id="SQLTest.GoToNextTest"
+                class="org.intellij.sdk.language.SQLTestGoToNextAction"
+                text="Go to Next Test"
+                description="Navigate to the next statement/query block">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift DOWN"/>
+            <add-to-group group-id="SQLTest.NavigationGroup"/>
+        </action>
+
+        <action id="SQLTest.GoToPreviousTest"
+                class="org.intellij.sdk.language.SQLTestGoToPreviousAction"
+                text="Go to Previous Test"
+                description="Navigate to the previous statement/query block">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift UP"/>
+            <add-to-group group-id="SQLTest.NavigationGroup"/>
+        </action>
+    </actions>
 </idea-plugin>


### PR DESCRIPTION
### Navigation Actions

Jump between tests with keyboard shortcuts:

- **Ctrl+Shift+Down** → Go to Next Test (next `statement`/`query`)
- **Ctrl+Shift+Up** → Go to Previous Test

Also available via **Go To → SQLTest** menu.

Only active when editing `.test` files. Scrolls the matching directive to center of screen.

Part of #13 (stretch goals)