### PR TITLE
fix: createElement returns null, preventing files from opening in CLion

### DIFF
--- a/src/main/java/org/intellij/sdk/language/SQLTestParserDefinition.java
+++ b/src/main/java/org/intellij/sdk/language/SQLTestParserDefinition.java
@@ -3,6 +3,7 @@
 package org.intellij.sdk.language;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ParserDefinition;
 import com.intellij.lang.PsiParser;
 import com.intellij.lexer.Lexer;
@@ -77,7 +78,7 @@ public class SQLTestParserDefinition implements ParserDefinition {
     @NotNull
     @Override
     public PsiElement createElement(ASTNode node) {
-        return null;
+        return new ASTWrapperPsiElement(node);
     }
 
 }

--- a/src/test/java/org/intellij/sdk/language/SQLTestFileOpenTest.java
+++ b/src/test/java/org/intellij/sdk/language/SQLTestFileOpenTest.java
@@ -1,0 +1,47 @@
+package org.intellij.sdk.language;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.tree.IElementType;
+import org.intellij.sdk.language.psi.TestElementType;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Verifies that createElement returns a valid PsiElement (not null).
+ * The old code returned null, causing NPEs when CLion opened .test files.
+ */
+public class SQLTestFileOpenTest {
+
+    @Test
+    public void testCreateElementReturnsNonNull() {
+        SQLTestParserDefinition parserDef = new SQLTestParserDefinition();
+
+        // Create a mock ASTNode — in the real IDE, this is called for every
+        // node in the PSI tree when a file is opened
+        IElementType elementType = new TestElementType("test_element");
+        ASTNode mockNode = new com.intellij.psi.impl.source.tree.LeafPsiElement(elementType, "test");
+
+        PsiElement result = parserDef.createElement(mockNode);
+
+        Assert.assertNotNull("createElement must not return null — this causes NPEs " +
+                "when the IDE opens .test files", result);
+        Assert.assertTrue("Should return ASTWrapperPsiElement",
+                result instanceof ASTWrapperPsiElement);
+    }
+
+    @Test
+    public void testCreateElementWorksForMultipleTypes() {
+        SQLTestParserDefinition parserDef = new SQLTestParserDefinition();
+
+        // Test with various element types that appear in .test files
+        String[] types = {"statement", "query", "loop", "comment", "sql", "result_line"};
+        for (String type : types) {
+            IElementType et = new TestElementType(type);
+            ASTNode node = new com.intellij.psi.impl.source.tree.LeafPsiElement(et, "content");
+            PsiElement result = parserDef.createElement(node);
+            Assert.assertNotNull("createElement returned null for type '" + type + "'", result);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`.test` files fail to open in CLion (and other IntelliJ-based IDEs). The editor tab appears but the file content doesn't render — no syntax highlighting, no structure view, nothing.

## Root Cause

`SQLTestParserDefinition.createElement()` returns `null`:

```java
public PsiElement createElement(ASTNode node) {
    return null;  // ← every AST node gets a null PsiElement
}
```

When the IDE opens a `.test` file, IntelliJ's PSI framework calls `createElement` for each AST node to build the PSI tree. Returning `null` causes `NullPointerException`s throughout the framework — the file viewer, syntax highlighter, folding builder, structure view, annotator, and line markers all fail silently or crash.

## Fix

Return `ASTWrapperPsiElement(node)` — the standard wrapper for AST nodes that don't have specialized PSI element classes:

```java
public PsiElement createElement(ASTNode node) {
    return new ASTWrapperPsiElement(node);
}
```

This is the expected implementation when the BNF grammar uses only token types (no composite elements with custom PSI classes). The `ASTWrapperPsiElement` delegates all PSI operations to the underlying AST node.

## Testing

- `./gradlew build` — passes
- `./gradlew test` — all 25 lexer tests pass